### PR TITLE
Add support for sparse depth maps

### DIFF
--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -225,8 +225,10 @@ def ds_nerf_depth_loss(
     Returns:
         Depth loss scalar.
     """
+    depth_mask = (termination_depth > 0)
+    
     loss = -torch.log(weights + EPS) * torch.exp(-((steps - termination_depth[:, None]) ** 2) / (2 * sigma)) * lengths
-    loss = loss.sum(-2) * (termination_depth > 0)
+    loss = loss.sum(-2) * depth_mask
     return torch.mean(loss)
 
 
@@ -248,6 +250,8 @@ def urban_radiance_field_depth_loss(
     Returns:
         Depth loss scalar.
     """
+    depth_mask = (termination_depth > 0)
+    
     # Expected depth loss
     expected_depth_loss = (termination_depth - predicted_depth) ** 2
 
@@ -263,8 +267,7 @@ def urban_radiance_field_depth_loss(
     line_of_sight_loss_empty = (line_of_sight_loss_empty_mask * weights**2).sum(-2)
     line_of_sight_loss = line_of_sight_loss_near + line_of_sight_loss_empty
     
-    termination_depth = termination_depth[...,0]
-    loss = (expected_depth_loss + line_of_sight_loss) * (termination_depth>0)
+    loss = (expected_depth_loss + line_of_sight_loss) * depth_mask
     return torch.mean(loss)
 
 

--- a/nerfstudio/model_components/losses.py
+++ b/nerfstudio/model_components/losses.py
@@ -225,8 +225,8 @@ def ds_nerf_depth_loss(
     Returns:
         Depth loss scalar.
     """
-    depth_mask = (termination_depth > 0)
-    
+    depth_mask = termination_depth > 0
+
     loss = -torch.log(weights + EPS) * torch.exp(-((steps - termination_depth[:, None]) ** 2) / (2 * sigma)) * lengths
     loss = loss.sum(-2) * depth_mask
     return torch.mean(loss)
@@ -250,8 +250,8 @@ def urban_radiance_field_depth_loss(
     Returns:
         Depth loss scalar.
     """
-    depth_mask = (termination_depth > 0)
-    
+    depth_mask = termination_depth > 0
+
     # Expected depth loss
     expected_depth_loss = (termination_depth - predicted_depth) ** 2
 
@@ -266,7 +266,7 @@ def urban_radiance_field_depth_loss(
     line_of_sight_loss_empty_mask = steps < termination_depth - sigma
     line_of_sight_loss_empty = (line_of_sight_loss_empty_mask * weights**2).sum(-2)
     line_of_sight_loss = line_of_sight_loss_near + line_of_sight_loss_empty
-    
+
     loss = (expected_depth_loss + line_of_sight_loss) * depth_mask
     return torch.mean(loss)
 

--- a/nerfstudio/models/depth_nerfacto.py
+++ b/nerfstudio/models/depth_nerfacto.py
@@ -118,8 +118,10 @@ class DepthNerfactoModel(NerfactoModel):
             far_plane=torch.max(ground_truth_depth),
         )
         images["depth"] = torch.cat([ground_truth_depth_colormap, predicted_depth_colormap], dim=1)
-        depth_mask = (ground_truth_depth > 0)
-        metrics["depth_mse"] = torch.nn.functional.mse_loss(outputs["depth"][depth_mask], ground_truth_depth[depth_mask])
+        depth_mask = ground_truth_depth > 0
+        metrics["depth_mse"] = torch.nn.functional.mse_loss(
+            outputs["depth"][depth_mask], ground_truth_depth[depth_mask]
+        )
         return metrics, images
 
     def _get_sigma(self):


### PR DESCRIPTION
# Background

In nerfstudio, the losses for depth don't support sparse depth maps.  

# Description

1. Modified `ds_nerf_depth_loss`, `urban_radiance_field_depth_loss` in `losses.py`.

2. Modified the way of computing `depth_mse` in eval. 

3. Fixed typo `Depht` -> `Depth`.

# Verification
Train `depth-nerfacto` with the `Replica` Dataset using only two views with sparse depth supervision (randomly masking out 90% of the depth map). left: groundtruth sparse depth map. right: predicted dense depth map. Results below are generated using `ds_nerf_depth_loss`. 

![Screenshot 2023-02-07 at 2 05 44 PM](https://user-images.githubusercontent.com/107962411/217377380-6c098669-5027-4e10-b73f-178bc4eee04c.png)

![Screenshot 2023-02-07 at 2 06 34 PM](https://user-images.githubusercontent.com/107962411/217377523-3313fa9c-2197-4b99-865b-de023edc94bf.png)

